### PR TITLE
Upgrade Azure.Identity to allow overriding default TenantId

### DIFF
--- a/src/ClrPro.Azure.LocalCredentialBridge/ClrPro.Azure.LocalCredentialBridge.csproj
+++ b/src/ClrPro.Azure.LocalCredentialBridge/ClrPro.Azure.LocalCredentialBridge.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.6.0" />
+    <PackageReference Include="Azure.Identity" Version="1.8.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />


### PR DESCRIPTION
Version 1.7.0 of Azure.Identity introduced support for setting `TenantId` on `DefaultAzureCredentialOptions` object, which is necessary when your Azure account is invited to multiple tenants. I have skipped version 1.7.0 and simply upgraded to the latest version.