### PR TITLE
Add ability to pack and start as a dotnet tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Local Credentials Bridge
+
+## Using as a Dotnet Tool
+
+Luckily, WebApis can also be packaged as dotnet tools and ran. To do this simple use the following commands from the solution root.
+
+`dotnet pack`
+
+`dotnet tool update -g --add-source ./pack ClrPro.AzureFX.LocalCredentialBridge`
+
+Then run with the following command:
+
+`az-credentials-bridge`

--- a/src/ClrPro.AzureFX.LocalCredentialBridge/ClrPro.AzureFX.LocalCredentialBridge.csproj
+++ b/src/ClrPro.AzureFX.LocalCredentialBridge/ClrPro.AzureFX.LocalCredentialBridge.csproj
@@ -5,6 +5,11 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <IsPackable>true</IsPackable>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>az-credentials-bridge</ToolCommandName>
+    <PackageOutputPath>./nupkg</PackageOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ClrPro.AzureFX.LocalCredentialBridge/ClrPro.AzureFX.LocalCredentialBridge.csproj
+++ b/src/ClrPro.AzureFX.LocalCredentialBridge/ClrPro.AzureFX.LocalCredentialBridge.csproj
@@ -9,7 +9,7 @@
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>az-credentials-bridge</ToolCommandName>
-    <PackageOutputPath>./nupkg</PackageOutputPath>
+    <PackageOutputPath>../../pack</PackageOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ClrPro.AzureFX.LocalCredentialBridge/Program.cs
+++ b/src/ClrPro.AzureFX.LocalCredentialBridge/Program.cs
@@ -12,6 +12,8 @@ const string azureDefaultsOptionsPath = "AzureDefaults";
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.WebHost.UseUrls("http://+:40342");
+
 builder.Services.AddMemoryCache();
 
 // Add services to the container.

--- a/src/ClrPro.AzureFX.LocalCredentialBridge/appsettings.json
+++ b/src/ClrPro.AzureFX.LocalCredentialBridge/appsettings.json
@@ -5,7 +5,6 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "ASPNETCORE_URLS": "http://+:40342",
   "LocalCredentialBridge": {
     "LocalTokensPath": "%USERPROFILE%/.LocalCredentialBridgeTokens",
     "RemoteTokensPath": "/var/opt/azcmagent/tokens",

--- a/src/ClrPro.AzureFX.LocalCredentialBridge/appsettings.json
+++ b/src/ClrPro.AzureFX.LocalCredentialBridge/appsettings.json
@@ -5,6 +5,7 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "ASPNETCORE_URLS": "http://+:40342",
   "LocalCredentialBridge": {
     "LocalTokensPath": "%USERPROFILE%/.LocalCredentialBridgeTokens",
     "RemoteTokensPath": "/var/opt/azcmagent/tokens",


### PR DESCRIPTION
Excellent tool, this has saved a lot of ache for me. Just a couple additions. You can pack webapis as a dotnet tool, which makes it easier to distribute with the team.

Next steps here if you ever wanted to, would be to have a GitHub action build and push to a nuget feed.